### PR TITLE
Use 'thousand' setting instead of 'group' for formatting

### DIFF
--- a/src/format.js
+++ b/src/format.js
@@ -41,6 +41,7 @@ function createAccountingConfig(locale, options) {
   return {
     ...formatConfig,
     symbol: symbolOpt,
+    thousand: formatConfig.group,
   };
 }
 

--- a/src/format.js
+++ b/src/format.js
@@ -39,9 +39,12 @@ function createAccountingConfig(locale, options) {
   const symbolOpt = formatConfig.symbol[options.symbol] || formatConfig.symbol.primary;
 
   return {
+    // This is a correction for the wrong `formatConfig` coming from json-reference
+    // Intentionally left above the spread to automatically prefer the `thousand` propery
+    // if it eventually comes from `currency-format.v2.json`.
+    thousand: formatConfig.group,
     ...formatConfig,
     symbol: symbolOpt,
-    thousand: formatConfig.group,
   };
 }
 

--- a/test/specs/format.js
+++ b/test/specs/format.js
@@ -29,6 +29,11 @@ describe('format', () => {
 
     expect(currency(1200.00, 'en-AU', options)).to.equal('$1,200');
     expect(currency(2000.00, 'en-AU', options)).to.equal('$2,000');
-    expect(currency(1200.00, 'de', options)).to.equal('€1,200');
+    expect(currency(1200.00, 'de', options)).to.equal('€1.200');
+  });
+
+  it('REGRESSION: it should format based on es-AR locale', () => {
+    const result = currency(16409, 'es-AR');
+    expect(result).to.equal('ARS16.409,00');
   });
 });


### PR DESCRIPTION
We were incorrectly passing the `group` property to accounting.js when it expects the `thousand` property to denote how to separate large numbers.